### PR TITLE
Search screen text color

### DIFF
--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -102,7 +102,10 @@ function Input({ onSearch }: { onSearch: (input: string) => void }) {
                 }}
                 onSubmitEditing={handleSearch}
                 returnKeyType="search"
-                style={{ flex: 1 }}
+                style={{
+                  flex: 1,
+                  color: colors.foreground,
+                }}
                 className="text-xl font-bold"
             />
 


### PR DESCRIPTION
Dev process check since there doesn't seem to be a lot of activity except pablo7z :-)

- In the Search screen, fix the text color so that when the device switches to dark mode the search term is visible.
