### PR TITLE
Fix README installation instructions and upgrade react-native-ios-utilities to 4.5.3 to fix compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 # Installation
 
 ```bash
-git clone https://github.com/pablof7z/snapstr
-cd snapstr
+git clone https://github.com/pablof7z/olas
+cd olas
+git submodule update --init --recursive
 pnpm install
 
 cd apps/mobile

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -90,7 +90,7 @@
     "react-native-gifted-charts": "^1.4.47",
     "react-native-gifted-chat": "^2.6.4",
     "react-native-ios-context-menu": "^2.5.2",
-    "react-native-ios-utilities": "^4.5.1",
+    "react-native-ios-utilities": "^4.5.3",
     "react-native-keyboard-controller": "^1.14.3",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-markdown-display": "^7.0.2",


### PR DESCRIPTION
I was getting the following errors when running `pnpm ios`, which were fixed after upgrading `react-native-ios-utilities`.

```
› Packaging react-native Pods/React-RCTAppDelegate » libReact-RCTAppDelegate.a

❌  (../../node_modules/react-native-ios-utilities/ios/Sources/Extensions+CaseIterable/CAGradientLayerType+CaseIterable.swift:10:32)

   8 | import Foundation
   9 | 
> 10 | extension CAGradientLayerType: CaseIterable {
     |                                ^ redundant conformance of 'CAGradientLayerType' to protocol 'CaseIterable'
  11 | 
  12 |   public static var allCases: [Self] = {
  13 |     var cases: [Self] = [


❌  (../../node_modules/react-native-ios-utilities/ios/Sources/Extensions+CaseIterable/UIViewAnimationCurve+CaseIterable.swift:10:34)

   8 | import Foundation
   9 | 
> 10 | extension UIView.AnimationCurve: CaseIterable {
     |                                  ^ redundant conformance of 'UIView.AnimationCurve' to protocol 'CaseIterable'
  11 | 
  12 |   public static var allCases: [UIView.AnimationCurve] = [
  13 |     .easeIn,


❌  (../../node_modules/react-native-ios-utilities/ios/Sources/Extensions+Helpers/UIViewAnimationCurve+CustomStringConvertible.swift:10:34)

   8 | import Foundation
   9 | 
> 10 | extension UIView.AnimationCurve: CustomStringConvertible {
     |                                  ^ redundant conformance of 'UIView.AnimationCurve' to protocol 'CustomStringConvertible'
  11 | 
  12 |   public var description: String {
  13 |     switch self {
```