### PR TITLE
Initialize empty array when follow list is undefined

### DIFF
--- a/apps/mobile/hooks/follows.ts
+++ b/apps/mobile/hooks/follows.ts
@@ -11,7 +11,7 @@ export function useAllFollows() {
     const privateFollows = usePrivateFollows();
     
     // merge and return
-    const allFollows = new Set([...publicFollows, ...Array.from(privateFollows?.pubkeys ?? [])]);
+    const allFollows = new Set([...publicFollows ?? [], ...Array.from(privateFollows?.pubkeys ?? [])]);
     return allFollows;
 }
 


### PR DESCRIPTION
Without this, app was crashing first time I tried running it locally because `publicFollows` was `undefined`